### PR TITLE
Move fleet/fare/service area modification to IterationStartsEvent

### DIFF
--- a/src/main/java/org/matsim/optDRT/OptDrtConfigGroup.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtConfigGroup.java
@@ -154,6 +154,13 @@ public class OptDrtConfigGroup extends ReflectiveConfigGroup implements Modal {
 						"opt drt input shape file for initial service area is empty. Starting without any restriction regarding the drt service area...");
 			}
 		}
+
+		if (getFareAdjustmentApproach().equals(FareAdjustmentApproach.ModeSplitThreshold)) {
+			if (writeInfoInterval != 1) {
+				log.error("writeInfoInterval must be 1 for FareAdjustmentApproach.ModeSplitThreshold to guarantee that mode split data is updated");
+				throw new RuntimeException("writeInfoInterval must be 1 for FareAdjustmentApproach.ModeSplitThreshold to guarantee that mode split data is updated");
+			}
+		}
 	}
 
 	@StringGetter(FLUCTUATING_PERCENTAGE)

--- a/src/main/java/org/matsim/optDRT/OptDrtControlerListener.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtControlerListener.java
@@ -27,12 +27,14 @@ package org.matsim.optDRT;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.core.controler.events.IterationEndsEvent;
+import org.matsim.core.controler.events.IterationStartsEvent;
 import org.matsim.core.controler.listener.IterationEndsListener;
+import org.matsim.core.controler.listener.IterationStartsListener;
 
 /**
  * @author ikaddoura
  */
-public class OptDrtControlerListener implements IterationEndsListener {
+public class OptDrtControlerListener implements IterationStartsListener, IterationEndsListener {
 
     private static final Logger log = Logger.getLogger(OptDrtControlerListener.class);
 
@@ -61,21 +63,6 @@ public class OptDrtControlerListener implements IterationEndsListener {
 
     @Override
     public void notifyIterationEnds(IterationEndsEvent event) {
-        if (multiModeOptDrtCfg.getUpdateInterval() != 0
-                && event.getIteration() != this.scenario.getConfig().controler().getLastIteration()
-                && event.getIteration() <= optDrtConfigGroup.getUpdateEndFractionIteration() * this.scenario.getConfig().controler().getLastIteration()
-                && event.getIteration() % multiModeOptDrtCfg.getUpdateInterval() == 0.) {
-
-            log.info("Iteration " + event.getIteration() + ". Applying DRT strategies...");
-
-            this.optDrtFareStrategy.updateFares();
-            this.optDrtFleetStrategy.updateFleet();
-            this.optDrtServiceAreaStrategy.updateServiceArea();
-
-            log.info("Iteration " + event.getIteration() + ". Applying DRT strategies... Done.");
-
-        }
-
         if (optDrtConfigGroup.getWriteInfoInterval() != 0
                 && event.getIteration() % optDrtConfigGroup.getWriteInfoInterval() == 0.) {
 
@@ -85,4 +72,21 @@ public class OptDrtControlerListener implements IterationEndsListener {
         }
     }
 
+    @Override
+    public void notifyIterationStarts(IterationStartsEvent iterationStartsEvent) {
+        if (multiModeOptDrtCfg.getUpdateInterval() != 0
+                && iterationStartsEvent.getIteration() != this.scenario.getConfig().controler().getLastIteration()
+                && iterationStartsEvent.getIteration() <= optDrtConfigGroup.getUpdateEndFractionIteration() * this.scenario.getConfig().controler().getLastIteration() + 1
+                && ( iterationStartsEvent.getIteration() % multiModeOptDrtCfg.getUpdateInterval() == 1. || multiModeOptDrtCfg.getUpdateInterval() == 1 ) ) {
+
+            log.info("Iteration " + iterationStartsEvent.getIteration() + ". Applying DRT strategies...");
+
+            this.optDrtFareStrategy.updateFares();
+            this.optDrtFleetStrategy.updateFleet();
+            this.optDrtServiceAreaStrategy.updateServiceArea();
+
+            log.info("Iteration " + iterationStartsEvent.getIteration() + ". Applying DRT strategies... Done.");
+
+        }
+    }
 }

--- a/src/main/java/org/matsim/optDRT/OptDrtControlerListener.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtControlerListener.java
@@ -74,6 +74,7 @@ public class OptDrtControlerListener implements IterationStartsListener, Iterati
 
     @Override
     public void notifyIterationStarts(IterationStartsEvent iterationStartsEvent) {
+        // first run update methods which use data from the previous iteration
         if (multiModeOptDrtCfg.getUpdateInterval() != 0
                 && iterationStartsEvent.getIteration() != this.scenario.getConfig().controler().getLastIteration()
                 && iterationStartsEvent.getIteration() <= optDrtConfigGroup.getUpdateEndFractionIteration() * this.scenario.getConfig().controler().getLastIteration() + 1
@@ -88,5 +89,9 @@ public class OptDrtControlerListener implements IterationStartsListener, Iterati
             log.info("Iteration " + iterationStartsEvent.getIteration() + ". Applying DRT strategies... Done.");
 
         }
+        // then delete data from previous iteration to clean up for this iteration
+        this.optDrtFareStrategy.resetDataForThisIteration(iterationStartsEvent.getIteration());
+        this.optDrtFleetStrategy.resetDataForThisIteration(iterationStartsEvent.getIteration());
+        this.optDrtServiceAreaStrategy.resetDataForThisIteration(iterationStartsEvent.getIteration());
     }
 }

--- a/src/main/java/org/matsim/optDRT/OptDrtControlerListener.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtControlerListener.java
@@ -62,13 +62,13 @@ public class OptDrtControlerListener implements IterationStartsListener, Iterati
     }
 
     @Override
-    public void notifyIterationEnds(IterationEndsEvent event) {
+    public void notifyIterationEnds(IterationEndsEvent iterationEndsEvent) {
         if (optDrtConfigGroup.getWriteInfoInterval() != 0
-                && event.getIteration() % optDrtConfigGroup.getWriteInfoInterval() == 0.) {
+                && iterationEndsEvent.getIteration() % optDrtConfigGroup.getWriteInfoInterval() == 0.) {
 
-            this.optDrtFareStrategy.writeInfo();
-            this.optDrtFleetStrategy.writeInfo();
-            this.optDrtServiceAreaStrategy.writeInfo();
+            this.optDrtFareStrategy.writeInfo( iterationEndsEvent.getIteration() );
+            this.optDrtFleetStrategy.writeInfo( iterationEndsEvent.getIteration() );
+            this.optDrtServiceAreaStrategy.writeInfo( iterationEndsEvent.getIteration() );
         }
     }
 
@@ -82,16 +82,16 @@ public class OptDrtControlerListener implements IterationStartsListener, Iterati
 
             log.info("Iteration " + iterationStartsEvent.getIteration() + ". Applying DRT strategies...");
 
-            this.optDrtFareStrategy.updateFares();
-            this.optDrtFleetStrategy.updateFleet();
-            this.optDrtServiceAreaStrategy.updateServiceArea();
+            this.optDrtFareStrategy.updateFares( iterationStartsEvent.getIteration() );
+            this.optDrtFleetStrategy.updateFleet( iterationStartsEvent.getIteration() );
+            this.optDrtServiceAreaStrategy.updateServiceArea( iterationStartsEvent.getIteration() );
 
             log.info("Iteration " + iterationStartsEvent.getIteration() + ". Applying DRT strategies... Done.");
 
         }
         // then delete data from previous iteration to clean up for this iteration
-        this.optDrtFareStrategy.resetDataForThisIteration(iterationStartsEvent.getIteration());
-        this.optDrtFleetStrategy.resetDataForThisIteration(iterationStartsEvent.getIteration());
-        this.optDrtServiceAreaStrategy.resetDataForThisIteration(iterationStartsEvent.getIteration());
+        this.optDrtFareStrategy.resetDataForThisIteration( iterationStartsEvent.getIteration() );
+        this.optDrtFleetStrategy.resetDataForThisIteration( iterationStartsEvent.getIteration() );
+        this.optDrtServiceAreaStrategy.resetDataForThisIteration( iterationStartsEvent.getIteration() );
     }
 }

--- a/src/main/java/org/matsim/optDRT/OptDrtFareStrategy.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFareStrategy.java
@@ -29,5 +29,12 @@ public interface OptDrtFareStrategy extends EventHandler {
 	public void updateFares();
 
 	public void writeInfo();
+
+	/**
+	 * Separate this from the normal reset() method in ControlerListeners, because we have to ensure that last
+	 * iterations' data is kept until updateFares() was run in the following iteration. But delete data immediately
+	 * afterwards to not mix it up with the current iteration.
+	 */
+	public void resetDataForThisIteration(int iteration);
 }
 

--- a/src/main/java/org/matsim/optDRT/OptDrtFareStrategy.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFareStrategy.java
@@ -26,15 +26,15 @@ import org.matsim.core.events.handler.EventHandler;
  */
 
 public interface OptDrtFareStrategy extends EventHandler {
-	public void updateFares();
+	public void updateFares( int currentIteration );
 
-	public void writeInfo();
+	public void writeInfo( int currentIteration );
 
 	/**
 	 * Separate this from the normal reset() method in ControlerListeners, because we have to ensure that last
 	 * iterations' data is kept until updateFares() was run in the following iteration. But delete data immediately
 	 * afterwards to not mix it up with the current iteration.
 	 */
-	public void resetDataForThisIteration(int iteration);
+	public void resetDataForThisIteration( int currentIteration );
 }
 

--- a/src/main/java/org/matsim/optDRT/OptDrtFareStrategyDisabled.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFareStrategyDisabled.java
@@ -6,12 +6,12 @@ package org.matsim.optDRT;
 public class OptDrtFareStrategyDisabled implements OptDrtFareStrategy {
 
     @Override
-    public void updateFares() {}
+    public void updateFares( int currentIteration ) {}
 
     @Override
-    public void writeInfo() {}
+    public void writeInfo( int currentIteration ) {}
 
     @Override
-    public void resetDataForThisIteration(int iteration) {}
+    public void resetDataForThisIteration( int currentIteration ) {}
 
 }

--- a/src/main/java/org/matsim/optDRT/OptDrtFareStrategyDisabled.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFareStrategyDisabled.java
@@ -11,4 +11,7 @@ public class OptDrtFareStrategyDisabled implements OptDrtFareStrategy {
     @Override
     public void writeInfo() {}
 
+    @Override
+    public void resetDataForThisIteration(int iteration) {}
+
 }

--- a/src/main/java/org/matsim/optDRT/OptDrtFareStrategyModalSplit.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFareStrategyModalSplit.java
@@ -47,8 +47,6 @@ public class OptDrtFareStrategyModalSplit implements PersonDepartureEventHandler
     private Map<Integer, Double> timeBin2drtTrips = new HashMap<>();
     private Map<Map<Id<Person>, String>, Double> personDepartureInfo = new HashMap<>();
 
-    private Boolean updateFare;
-
     private final List<String> mainTransportModes = new LinkedList<>();
 
     private Set<Id<Person>> personList;
@@ -128,7 +126,6 @@ public class OptDrtFareStrategyModalSplit implements PersonDepartureEventHandler
             this.timeBin2totalTrips.put(timeBin, 0.);
             this.timeBin2drtTrips.put(timeBin, 0.);
         }
-        this.updateFare = false;
         lastRequestSubmission.clear();
         drtUserDepartureTime.clear();
         this.currentIteration = iteration;
@@ -161,15 +158,6 @@ public class OptDrtFareStrategyModalSplit implements PersonDepartureEventHandler
 
     @Override
     public void updateFares() {
-        this.updateFare = true;
-        for (int i = 0; i < timeBin2DrtModalStats.size(); i++) {
-            if (timeBin2totalTrips.get(i) == 0) {
-                timeBin2DrtModalStats.put(i, 0.);
-            } else {
-                timeBin2DrtModalStats.put(i, timeBin2drtTrips.get(i) / timeBin2totalTrips.get(i));
-            }
-            log.info("-- mode share of drt at timeBin " + i + " = " + timeBin2DrtModalStats.get(i));
-        }
         for (int timeBin = 0; timeBin <= getTimeBin(scenario.getConfig().qsim().getEndTime().seconds()); timeBin++) {
             double drtModeStats = timeBin2DrtModalStats.get(timeBin);
 
@@ -202,7 +190,6 @@ public class OptDrtFareStrategyModalSplit implements PersonDepartureEventHandler
 
     @Override
     public void writeInfo() {
-        if (!updateFare) {
             for (int i = 0; i < timeBin2DrtModalStats.size(); i++) {
                 if (timeBin2totalTrips.get(i) == 0) {
                     timeBin2DrtModalStats.put(i, 0.);
@@ -211,7 +198,6 @@ public class OptDrtFareStrategyModalSplit implements PersonDepartureEventHandler
                 }
                 log.info("-- mode share of drt at timeBin " + i + " = " + timeBin2DrtModalStats.get(i));
             }
-        } else {
             String runOutputDirectory = this.scenario.getConfig().controler().getOutputDirectory();
             if (!runOutputDirectory.endsWith("/")) runOutputDirectory = runOutputDirectory.concat("/");
 
@@ -248,7 +234,6 @@ public class OptDrtFareStrategyModalSplit implements PersonDepartureEventHandler
             } catch (IOException e) {
                 e.printStackTrace();
             }
-        }
     }
 
     @Override

--- a/src/main/java/org/matsim/optDRT/OptDrtFareStrategyModalSplit.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFareStrategyModalSplit.java
@@ -51,8 +51,6 @@ public class OptDrtFareStrategyModalSplit implements PersonDepartureEventHandler
 
     private Set<Id<Person>> personList;
 
-    private int currentIteration;
-
     private final OptDrtConfigGroup optDrtConfigGroup;
 
     private final EventsManager events;
@@ -119,7 +117,7 @@ public class OptDrtFareStrategyModalSplit implements PersonDepartureEventHandler
     public void reset(int iteration) {}
 
     @Override
-    public void resetDataForThisIteration(int iteration) {
+    public void resetDataForThisIteration( int currentIteration ) {
         int timeBinSize = getTimeBin(scenario.getConfig().qsim().getEndTime().seconds());
         for (int timeBin = 0; timeBin <= timeBinSize; timeBin++) {
             this.timeBin2DrtModalStats.put(timeBin, 0.);
@@ -128,11 +126,10 @@ public class OptDrtFareStrategyModalSplit implements PersonDepartureEventHandler
         }
         lastRequestSubmission.clear();
         drtUserDepartureTime.clear();
-        this.currentIteration = iteration;
 
         // collect real person Id
         this.personList = this.scenario.getPopulation().getPersons().keySet();
-        log.info("-- active persons in " + this.currentIteration + ".it are " + Arrays.toString(personList.toArray()));
+        log.info("-- active persons in " + currentIteration + ".it are " + Arrays.toString(personList.toArray()));
 
         // record main modes in this iteration
         List<TripStructureUtils.Trip> trips = new LinkedList<>();
@@ -146,7 +143,7 @@ public class OptDrtFareStrategyModalSplit implements PersonDepartureEventHandler
             if (!this.mainTransportModes.contains(mode))
                 this.mainTransportModes.add(mode);
         }
-        log.info("-- main mode in " + this.currentIteration + ".it are " + Arrays.toString(this.mainTransportModes.toArray()));
+        log.info("-- main mode in " + currentIteration + ".it are " + Arrays.toString(this.mainTransportModes.toArray()));
     }
 
     @Override
@@ -157,7 +154,7 @@ public class OptDrtFareStrategyModalSplit implements PersonDepartureEventHandler
     }
 
     @Override
-    public void updateFares() {
+    public void updateFares( int currentIteration ) {
         for (int timeBin = 0; timeBin <= getTimeBin(scenario.getConfig().qsim().getEndTime().seconds()); timeBin++) {
             double drtModeStats = timeBin2DrtModalStats.get(timeBin);
 
@@ -189,7 +186,7 @@ public class OptDrtFareStrategyModalSplit implements PersonDepartureEventHandler
     }
 
     @Override
-    public void writeInfo() {
+    public void writeInfo( int currentIteration ) {
             for (int i = 0; i < timeBin2DrtModalStats.size(); i++) {
                 if (timeBin2totalTrips.get(i) == 0) {
                     timeBin2DrtModalStats.put(i, 0.);

--- a/src/main/java/org/matsim/optDRT/OptDrtFareStrategyModalSplit.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFareStrategyModalSplit.java
@@ -118,7 +118,10 @@ public class OptDrtFareStrategyModalSplit implements PersonDepartureEventHandler
     }
 
     @Override
-    public void reset(int iteration) {
+    public void reset(int iteration) {}
+
+    @Override
+    public void resetDataForThisIteration(int iteration) {
         int timeBinSize = getTimeBin(scenario.getConfig().qsim().getEndTime().seconds());
         for (int timeBin = 0; timeBin <= timeBinSize; timeBin++) {
             this.timeBin2DrtModalStats.put(timeBin, 0.);

--- a/src/main/java/org/matsim/optDRT/OptDrtFareStrategyWaitingTime.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFareStrategyWaitingTime.java
@@ -66,7 +66,6 @@ class OptDrtFareStrategyWaitingTime
 	private final Map<Id<Person>, Double> drtUserDepartureTime = new HashMap<>();
 	private final Map<Integer, List<Double>> timeBin2waitingTimes = new HashMap<>();
 
-	private int currentIteration;
 	private int priceUpdateCounter;
 
 	private final OptDrtConfigGroup optDrtConfigGroup;
@@ -85,13 +84,11 @@ class OptDrtFareStrategyWaitingTime
 	public void reset(int iteration) {}
 
 	@Override
-	public void resetDataForThisIteration(int iteration) {
+	public void resetDataForThisIteration( int currentIteration ) {
 
 		lastRequestSubmission.clear();
 		drtUserDepartureTime.clear();
 		timeBin2waitingTimes.clear();
-
-		this.currentIteration = iteration;
 
 		// do not reset the fares from one iteration to the next one
 	}
@@ -122,7 +119,7 @@ class OptDrtFareStrategyWaitingTime
 	}
 
 	@Override
-	public void updateFares() {
+	public void updateFares( int currentIteration ) {
 		
 		priceUpdateCounter++;
 
@@ -224,7 +221,7 @@ class OptDrtFareStrategyWaitingTime
 	}
 
 	@Override
-	public void writeInfo() {
+	public void writeInfo( int currentIteration ) {
 		String runOutputDirectory = this.scenario.getConfig().controler().getOutputDirectory();
 		if (!runOutputDirectory.endsWith("/")) runOutputDirectory = runOutputDirectory.concat("/");
 		

--- a/src/main/java/org/matsim/optDRT/OptDrtFareStrategyWaitingTime.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFareStrategyWaitingTime.java
@@ -82,7 +82,10 @@ class OptDrtFareStrategyWaitingTime
 	}
 
 	@Override
-	public void reset(int iteration) {
+	public void reset(int iteration) {}
+
+	@Override
+	public void resetDataForThisIteration(int iteration) {
 
 		lastRequestSubmission.clear();
 		drtUserDepartureTime.clear();

--- a/src/main/java/org/matsim/optDRT/OptDrtFareStrategyWaitingTimePercentile.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFareStrategyWaitingTimePercentile.java
@@ -66,7 +66,6 @@ class OptDrtFareStrategyWaitingTimePercentile
 	private final Map<Id<Person>, Double> drtUserDepartureTime = new HashMap<>();
 	private final Map<Integer, List<Double>> timeBin2waitingTimes = new HashMap<>();
 
-	private int currentIteration;
 	private int priceUpdateCounter;
 
 	private final OptDrtConfigGroup optDrtConfigGroup;
@@ -91,13 +90,11 @@ class OptDrtFareStrategyWaitingTimePercentile
 	public void reset(int iteration) {}
 
 	@Override
-	public void resetDataForThisIteration(int iteration) {
+	public void resetDataForThisIteration( int currentIteration ) {
 
 		lastRequestSubmission.clear();
 		drtUserDepartureTime.clear();
 		timeBin2waitingTimes.clear();
-
-		this.currentIteration = iteration;
 
 		// do not reset the fares from one iteration to the next one
 	}
@@ -128,7 +125,7 @@ class OptDrtFareStrategyWaitingTimePercentile
 	}
 
 	@Override
-	public void updateFares() {
+	public void updateFares( int currentIteration ) {
 		
 		priceUpdateCounter++;
 						
@@ -153,7 +150,7 @@ class OptDrtFareStrategyWaitingTimePercentile
 				if ((cntAboveThreshold + cntBelowOrEqualsThreshold) > 0) {
 					shareOfTripsAboveWaitingTimeThreshold = (double) cntAboveThreshold / (double) (cntAboveThreshold + cntBelowOrEqualsThreshold);
 				} else {
-					log.warn("No drt trips in iteration " + this.currentIteration);
+					log.warn("No drt trips in previous iteration " + (currentIteration - 1));
 					shareOfTripsAboveWaitingTimeThreshold = 0.;
 				}
 				
@@ -244,7 +241,7 @@ class OptDrtFareStrategyWaitingTimePercentile
 	}
 
 	@Override
-	public void writeInfo() {
+	public void writeInfo( int currentIteration ) {
 		String runOutputDirectory = this.scenario.getConfig().controler().getOutputDirectory();
 		if (!runOutputDirectory.endsWith("/")) runOutputDirectory = runOutputDirectory.concat("/");
 		

--- a/src/main/java/org/matsim/optDRT/OptDrtFareStrategyWaitingTimePercentile.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFareStrategyWaitingTimePercentile.java
@@ -88,7 +88,10 @@ class OptDrtFareStrategyWaitingTimePercentile
 	}
 
 	@Override
-	public void reset(int iteration) {
+	public void reset(int iteration) {}
+
+	@Override
+	public void resetDataForThisIteration(int iteration) {
 
 		lastRequestSubmission.clear();
 		drtUserDepartureTime.clear();

--- a/src/main/java/org/matsim/optDRT/OptDrtFleetStrategy.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFleetStrategy.java
@@ -26,15 +26,15 @@ import org.matsim.core.events.handler.EventHandler;
  */
 
 public interface OptDrtFleetStrategy extends EventHandler {
-	public void updateFleet();
+	public void updateFleet( int currentIteration );
 
-	public void writeInfo();
+	public void writeInfo( int currentIteration );
 
 	/**
 	 * Separate this from the normal reset() method in ControlerListeners, because we have to ensure that last
 	 * iterations' data is kept until updateFares() was run in the following iteration. But delete data immediately
 	 * afterwards to not mix it up with the current iteration.
 	 */
-	public void resetDataForThisIteration(int iteration);
+	public void resetDataForThisIteration( int currentIteration );
 }
 

--- a/src/main/java/org/matsim/optDRT/OptDrtFleetStrategy.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFleetStrategy.java
@@ -29,5 +29,12 @@ public interface OptDrtFleetStrategy extends EventHandler {
 	public void updateFleet();
 
 	public void writeInfo();
+
+	/**
+	 * Separate this from the normal reset() method in ControlerListeners, because we have to ensure that last
+	 * iterations' data is kept until updateFares() was run in the following iteration. But delete data immediately
+	 * afterwards to not mix it up with the current iteration.
+	 */
+	public void resetDataForThisIteration(int iteration);
 }
 

--- a/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyAvgWaitingTime.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyAvgWaitingTime.java
@@ -76,7 +76,10 @@ class OptDrtFleetStrategyAvgWaitingTime
 	}
 
 	@Override
-	public void reset(int iteration) {
+	public void reset(int iteration) {}
+
+	@Override
+	public void resetDataForThisIteration(int iteration) {
 		drtUserDepartureTime.clear();
 		timeBin2waitingTimes.clear();
 

--- a/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyAvgWaitingTime.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyAvgWaitingTime.java
@@ -55,8 +55,6 @@ class OptDrtFleetStrategyAvgWaitingTime
 		PersonArrivalEventHandler {
 	private static final Logger log = Logger.getLogger(OptDrtFleetStrategyAvgWaitingTime.class);
 
-	private int currentIteration;
-
 	private final FleetSpecification fleetSpecification;
 
 	private final OptDrtConfigGroup optDrtConfigGroup;
@@ -79,17 +77,15 @@ class OptDrtFleetStrategyAvgWaitingTime
 	public void reset(int iteration) {}
 
 	@Override
-	public void resetDataForThisIteration(int iteration) {
+	public void resetDataForThisIteration( int currentIteration ) {
 		drtUserDepartureTime.clear();
 		timeBin2waitingTimes.clear();
-
-		this.currentIteration = iteration;
 
 		// do not reset vehicle counter
 	}
 
 	@Override
-	public void updateFleet() {
+	public void updateFleet( int currentIteration ) {
 
 		if (computeMaximumOfAvgWaitingTimePerTimeBin() >= optDrtConfigGroup.getWaitingTimeThresholdForFleetSizeAdjustment()) {
 			increaseFleet();
@@ -222,7 +218,7 @@ class OptDrtFleetStrategyAvgWaitingTime
 	}
 
 	@Override
-	public void writeInfo() {
+	public void writeInfo( int currentIteration ) {
 		String runOutputDirectory = this.scenario.getConfig().controler().getOutputDirectory();
 		if (!runOutputDirectory.endsWith("/"))
 			runOutputDirectory = runOutputDirectory.concat("/");

--- a/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyDisabled.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyDisabled.java
@@ -26,12 +26,12 @@ package org.matsim.optDRT;
 class OptDrtFleetStrategyDisabled implements OptDrtFleetStrategy {
 
 	@Override
-	public void updateFleet() {}
+	public void updateFleet( int currentIteration ) {}
 
 	@Override
-	public void writeInfo() {}
+	public void writeInfo( int currentIteration ) {}
 
 	@Override
-	public void resetDataForThisIteration(int iteration) {}
+	public void resetDataForThisIteration( int currentIteration ) {}
 }
 

--- a/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyDisabled.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyDisabled.java
@@ -29,8 +29,9 @@ class OptDrtFleetStrategyDisabled implements OptDrtFleetStrategy {
 	public void updateFleet() {}
 
 	@Override
-	public void writeInfo() {}	
-	
+	public void writeInfo() {}
 
+	@Override
+	public void resetDataForThisIteration(int iteration) {}
 }
 

--- a/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyProfit.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyProfit.java
@@ -61,7 +61,6 @@ class OptDrtFleetStrategyProfit
 	private double drtFareSum = 0.;
 	private double drtVehDistance_m = 0.;
 	private final Set<Id<DvrpVehicle>> drtVehicleIds = new HashSet<>();
-	private int currentIteration;
 
 	public OptDrtFleetStrategyProfit(FleetSpecification fleetSpecification, OptDrtConfigGroup optDrtConfigGroup,
 			Scenario scenario) {
@@ -74,18 +73,17 @@ class OptDrtFleetStrategyProfit
 	public void reset(int iteration) {}
 
 	@Override
-	public void resetDataForThisIteration(int iteration) {
+	public void resetDataForThisIteration( int currentIteration ) {
 		this.departedDrtUsers.clear();
 		this.drtFareSum = 0.;
 		this.drtVehDistance_m = 0.;
 		this.drtVehicleIds.clear();
-		this.currentIteration = iteration;
 
 		// do not reset vehicle counter
 	}
 
 	@Override
-	public void updateFleet() {
+	public void updateFleet( int currentIteration ) {
 		
 		if (computeProfit() >= optDrtConfigGroup.getProfitThresholdForFleetSizeAdjustment()) {
 			increaseFleet();
@@ -201,7 +199,7 @@ class OptDrtFleetStrategyProfit
 	}
 
 	@Override
-	public void writeInfo() {
+	public void writeInfo( int currentIteration ) {
 		// TODO Auto-generated method stub
 	}
 

--- a/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyProfit.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyProfit.java
@@ -71,7 +71,10 @@ class OptDrtFleetStrategyProfit
 	}
 
 	@Override
-	public void reset(int iteration) {
+	public void reset(int iteration) {}
+
+	@Override
+	public void resetDataForThisIteration(int iteration) {
 		this.departedDrtUsers.clear();
 		this.drtFareSum = 0.;
 		this.drtVehDistance_m = 0.;

--- a/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyWaitingTimePercentile.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyWaitingTimePercentile.java
@@ -59,7 +59,7 @@ class OptDrtFleetStrategyWaitingTimePercentile implements OptDrtFleetStrategy, P
 
 	private final Config config;
 
-	private int currentIteration;
+//	private int currentIteration;
 
 	private int vehicleCounter = 0;
 
@@ -80,17 +80,15 @@ class OptDrtFleetStrategyWaitingTimePercentile implements OptDrtFleetStrategy, P
 	public void reset(int iteration) {}
 
 	@Override
-	public void resetDataForThisIteration(int iteration) {
+	public void resetDataForThisIteration( int currentIteration ) {
 		drtUserDepartureTime.clear();
 		waitingTimes.clear();
-    	
-    	this.currentIteration = iteration;
     	
     	// do not reset vehicle counter
 	}
 
 	@Override
-	public void updateFleet() {	
+	public void updateFleet( int currentIteration ) {
 		
 		int vehiclesBefore = fleetSpecification.getVehicleSpecifications().size();		
 		log.info("Current fleet size: " + vehiclesBefore);
@@ -112,7 +110,7 @@ class OptDrtFleetStrategyWaitingTimePercentile implements OptDrtFleetStrategy, P
 			}
 		}
 		
-		String line = this.config.controler().getRunId() + ";" + this.currentIteration + ";" + vehiclesBefore + ";" + currentWaitingTimePercentile + ";" + targetWaitingTimePercentile + ";" + cntAboveThreshold + ";" + cntBelowOrEqualsThreshold;
+		String line = this.config.controler().getRunId() + ";" + currentIteration + ";" + vehiclesBefore + ";" + currentWaitingTimePercentile + ";" + targetWaitingTimePercentile + ";" + cntAboveThreshold + ";" + cntBelowOrEqualsThreshold;
 		iterationStatistics.add(line);
 		
 		if (Double.isNaN(currentWaitingTimePercentile)) {
@@ -273,7 +271,7 @@ class OptDrtFleetStrategyWaitingTimePercentile implements OptDrtFleetStrategy, P
 	}
 
 	@Override
-	public void writeInfo() {
+	public void writeInfo( int currentIteration ) {
 		String runOutputDirectory = this.config.controler().getOutputDirectory();
 		if (!runOutputDirectory.endsWith("/")) runOutputDirectory = runOutputDirectory.concat("/");
 		

--- a/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyWaitingTimePercentile.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyWaitingTimePercentile.java
@@ -59,8 +59,6 @@ class OptDrtFleetStrategyWaitingTimePercentile implements OptDrtFleetStrategy, P
 
 	private final Config config;
 
-//	private int currentIteration;
-
 	private int vehicleCounter = 0;
 
 	private final Map<Id<Person>, Double> drtUserDepartureTime = new HashMap<>();

--- a/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyWaitingTimePercentile.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtFleetStrategyWaitingTimePercentile.java
@@ -77,7 +77,10 @@ class OptDrtFleetStrategyWaitingTimePercentile implements OptDrtFleetStrategy, P
 	}
 
 	@Override
-	public void reset(int iteration) {
+	public void reset(int iteration) {}
+
+	@Override
+	public void resetDataForThisIteration(int iteration) {
 		drtUserDepartureTime.clear();
 		waitingTimes.clear();
     	
@@ -165,7 +168,7 @@ class OptDrtFleetStrategyWaitingTimePercentile implements OptDrtFleetStrategy, P
 		for (Double waitingTime : this.waitingTimes) {
 			waitStats.addValue(waitingTime);
 		}
-		double percentile = waitStats.getPercentile(percentage * 100);	
+		double percentile = waitStats.getPercentile(percentage * 100);
 		return percentile;
 	}
 

--- a/src/main/java/org/matsim/optDRT/OptDrtServiceAreaStrategy.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtServiceAreaStrategy.java
@@ -26,15 +26,15 @@ import org.matsim.core.events.handler.EventHandler;
  */
 
 public interface OptDrtServiceAreaStrategy extends EventHandler {
-	public void updateServiceArea();
+	public void updateServiceArea( int currentIteration );
 
-	public void writeInfo();
+	public void writeInfo( int currentIteration );
 
 	/**
 	 * Separate this from the normal reset() method in ControlerListeners, because we have to ensure that last
 	 * iterations' data is kept until updateFares() was run in the following iteration. But delete data immediately
 	 * afterwards to not mix it up with the current iteration.
 	 */
-	public void resetDataForThisIteration(int iteration);
+	public void resetDataForThisIteration( int currentIteration );
 }
 

--- a/src/main/java/org/matsim/optDRT/OptDrtServiceAreaStrategy.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtServiceAreaStrategy.java
@@ -29,5 +29,12 @@ public interface OptDrtServiceAreaStrategy extends EventHandler {
 	public void updateServiceArea();
 
 	public void writeInfo();
+
+	/**
+	 * Separate this from the normal reset() method in ControlerListeners, because we have to ensure that last
+	 * iterations' data is kept until updateFares() was run in the following iteration. But delete data immediately
+	 * afterwards to not mix it up with the current iteration.
+	 */
+	public void resetDataForThisIteration(int iteration);
 }
 

--- a/src/main/java/org/matsim/optDRT/OptDrtServiceAreaStrategyDemand.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtServiceAreaStrategyDemand.java
@@ -86,7 +86,10 @@ public class OptDrtServiceAreaStrategyDemand
 	}
 
 	@Override
-	public void reset(int iteration) {
+	public void reset(int iteration) {}
+
+	@Override
+	public void resetDataForThisIteration(int iteration) {
 		currentIteration = iteration;
 
 		// do not clear the entries in the map, only set the demand levels to zero.

--- a/src/main/java/org/matsim/optDRT/OptDrtServiceAreaStrategyDemand.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtServiceAreaStrategyDemand.java
@@ -71,7 +71,6 @@ public class OptDrtServiceAreaStrategyDemand
 	private final DefaultPassengerRequestValidator delegate = new DefaultPassengerRequestValidator();
 	private final Map<Integer, SimpleFeature> features;
 	private final Map<Integer, Integer> currentServiceAreaGeometryIds2Demand = new HashMap<>();
-	private int currentIteration;
 
 	private final OptDrtConfigGroup optDrtCfg;
 
@@ -89,9 +88,7 @@ public class OptDrtServiceAreaStrategyDemand
 	public void reset(int iteration) {}
 
 	@Override
-	public void resetDataForThisIteration(int iteration) {
-		currentIteration = iteration;
-
+	public void resetDataForThisIteration( int currentIteration ) {
 		// do not clear the entries in the map, only set the demand levels to zero.
 		for (Integer area : currentServiceAreaGeometryIds2Demand.keySet()) {
 			this.currentServiceAreaGeometryIds2Demand.put(area, 0);
@@ -186,7 +183,7 @@ public class OptDrtServiceAreaStrategyDemand
 	}
 
 	@Override
-	public void updateServiceArea() {
+	public void updateServiceArea( int currentIteration ) {
 		
 		// reduce service area
 		List<Integer> geometriesWithDemandBelowThreshold = new ArrayList<>();
@@ -265,7 +262,7 @@ public class OptDrtServiceAreaStrategyDemand
 	}
 
 	@Override
-	public void writeInfo() {
+	public void writeInfo( int currentIteration ) {
 		
 		if (!shpFileWrittenOut) {
 			String runOutputDirectory = this.scenario.getConfig().controler().getOutputDirectory();

--- a/src/main/java/org/matsim/optDRT/OptDrtServiceAreaStrategyDisabled.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtServiceAreaStrategyDisabled.java
@@ -31,5 +31,8 @@ public class OptDrtServiceAreaStrategyDisabled implements OptDrtServiceAreaStrat
 	@Override
 	public void writeInfo() {}
 
+	@Override
+	public void resetDataForThisIteration(int iteration) {}
+
 }
 

--- a/src/main/java/org/matsim/optDRT/OptDrtServiceAreaStrategyDisabled.java
+++ b/src/main/java/org/matsim/optDRT/OptDrtServiceAreaStrategyDisabled.java
@@ -26,13 +26,13 @@ package org.matsim.optDRT;
 public class OptDrtServiceAreaStrategyDisabled implements OptDrtServiceAreaStrategy {
 
 	@Override
-	public void updateServiceArea() {}
+	public void updateServiceArea( int currentIteration ) {}
 
 	@Override
-	public void writeInfo() {}
+	public void writeInfo( int currentIteration ) {}
 
 	@Override
-	public void resetDataForThisIteration(int iteration) {}
+	public void resetDataForThisIteration( int currentIteration ) {}
 
 }
 

--- a/src/test/java/org/matsim/run/RunOptDrtEquilAreaStrategyTest.java
+++ b/src/test/java/org/matsim/run/RunOptDrtEquilAreaStrategyTest.java
@@ -78,7 +78,7 @@ public class RunOptDrtEquilAreaStrategyTest {
 			        records.add(Arrays.asList(values));
 			    }
 			}
-			Assert.assertEquals("Wrong number of drt vehicles in last iteration:", 1., Double.valueOf(records.get(11).get(2)), MatsimTestUtils.EPSILON);	
+			Assert.assertEquals("Wrong number of drt vehicles in last iteration:", 1., Double.valueOf(records.get(12).get(2)), MatsimTestUtils.EPSILON);
 		}
 		
 		{
@@ -90,7 +90,7 @@ public class RunOptDrtEquilAreaStrategyTest {
 			        records.add(Arrays.asList(values));
 			    }
 			}
-			Assert.assertEquals("Wrong number of drt1 vehicles in last iteration:", 0., Double.valueOf(records.get(11).get(2)), MatsimTestUtils.EPSILON);	
+			Assert.assertEquals("Wrong number of drt1 vehicles in last iteration:", 0., Double.valueOf(records.get(12).get(2)), MatsimTestUtils.EPSILON);
 		}
 		
 	}

--- a/src/test/java/org/matsim/run/RunOptDrtEquilFareStrategyTest.java
+++ b/src/test/java/org/matsim/run/RunOptDrtEquilFareStrategyTest.java
@@ -78,7 +78,7 @@ public class RunOptDrtEquilFareStrategyTest {
 			        records.add(Arrays.asList(values));
 			    }
 			}
-			Assert.assertEquals("Wrong fare surcharge in time bin 4 for drt in final iteration:", 0., Double.valueOf(records.get(5).get(5)), MatsimTestUtils.EPSILON);		
+			Assert.assertEquals("Wrong fare surcharge in time bin 4 for drt in final iteration:", 0., Double.valueOf(records.get(6).get(5)), MatsimTestUtils.EPSILON);
 		}
 		
 		{
@@ -90,7 +90,7 @@ public class RunOptDrtEquilFareStrategyTest {
 			        records.add(Arrays.asList(values));
 			    }
 			}
-			Assert.assertEquals("Wrong fare surcharge in time bin 4 for drt1 in final iteration:", 0.75, Double.valueOf(records.get(5).get(5)), MatsimTestUtils.EPSILON);		
+			Assert.assertEquals("Wrong fare surcharge in time bin 4 for drt1 in final iteration:", 0.75, Double.valueOf(records.get(6).get(5)), MatsimTestUtils.EPSILON);
 		}
 	}
 

--- a/src/test/java/org/matsim/run/RunOptDrtEquilFleetStrategyTest.java
+++ b/src/test/java/org/matsim/run/RunOptDrtEquilFleetStrategyTest.java
@@ -67,7 +67,7 @@ public class RunOptDrtEquilFleetStrategyTest {
 		
 		controler.run();
 		
-		Assert.assertEquals("Wrong score.", -74.31969437897558, controler.getScoreStats().getScoreHistory().get(ScoreItem.executed).get(0), MatsimTestUtils.EPSILON);
+//		Assert.assertEquals("Wrong score.", -74.31969437897558, controler.getScoreStats().getScoreHistory().get(ScoreItem.executed).get(0), MatsimTestUtils.EPSILON);
 
 		{
 			List<List<String>> records = new ArrayList<>();

--- a/src/test/java/org/matsim/run/RunOptDrtEquilFleetStrategyTest.java
+++ b/src/test/java/org/matsim/run/RunOptDrtEquilFleetStrategyTest.java
@@ -67,7 +67,7 @@ public class RunOptDrtEquilFleetStrategyTest {
 		
 		controler.run();
 		
-//		Assert.assertEquals("Wrong score.", -74.31969437897558, controler.getScoreStats().getScoreHistory().get(ScoreItem.executed).get(0), MatsimTestUtils.EPSILON);
+		Assert.assertEquals("Wrong score.", -74.31969437897558, controler.getScoreStats().getScoreHistory().get(ScoreItem.executed).get(0), MatsimTestUtils.EPSILON);
 
 		{
 			List<List<String>> records = new ArrayList<>();
@@ -79,7 +79,7 @@ public class RunOptDrtEquilFleetStrategyTest {
 			    }
 			}
 			Assert.assertEquals("Wrong number of drt1 vehicles in first iteration:", 1., Double.valueOf(records.get(1).get(2)), MatsimTestUtils.EPSILON);		
-			Assert.assertEquals("Wrong number of drt1 vehicles in last iteration:", 11., Double.valueOf(records.get(11).get(2)), MatsimTestUtils.EPSILON);	
+			Assert.assertEquals("Wrong number of drt1 vehicles in last iteration:", 11., Double.valueOf(records.get(12).get(2)), MatsimTestUtils.EPSILON);
 		}
 		
 		{
@@ -92,7 +92,7 @@ public class RunOptDrtEquilFleetStrategyTest {
 			    }
 			}
 			Assert.assertEquals("Wrong number of drt vehicles in first iteration:", 1., Double.valueOf(records.get(1).get(2)), MatsimTestUtils.EPSILON);		
-			Assert.assertEquals("Wrong number of drt vehicles in last iteration:", 1., Double.valueOf(records.get(11).get(2)), MatsimTestUtils.EPSILON);	
+			Assert.assertEquals("Wrong number of drt vehicles in last iteration:", 1., Double.valueOf(records.get(12).get(2)), MatsimTestUtils.EPSILON);
 		}
 	}	
 	
@@ -133,7 +133,7 @@ public class RunOptDrtEquilFleetStrategyTest {
 			    }
 			}
 			Assert.assertEquals("Wrong number of drt1 vehicles in first iteration:", 1., Double.valueOf(records.get(1).get(2)), MatsimTestUtils.EPSILON);		
-			Assert.assertEquals("Wrong number of drt1 vehicles in last iteration:", 3., Double.valueOf(records.get(11).get(2)), MatsimTestUtils.EPSILON);	
+			Assert.assertEquals("Wrong number of drt1 vehicles in last iteration:", 3., Double.valueOf(records.get(12).get(2)), MatsimTestUtils.EPSILON);
 		}
 		
 		{
@@ -146,7 +146,7 @@ public class RunOptDrtEquilFleetStrategyTest {
 			    }
 			}
 			Assert.assertEquals("Wrong number of drt vehicles in first iteration:", 1., Double.valueOf(records.get(1).get(2)), MatsimTestUtils.EPSILON);		
-			Assert.assertEquals("Wrong number of drt vehicles in last iteration:", 1., Double.valueOf(records.get(11).get(2)), MatsimTestUtils.EPSILON);	
+			Assert.assertEquals("Wrong number of drt vehicles in last iteration:", 1., Double.valueOf(records.get(12).get(2)), MatsimTestUtils.EPSILON);
 		}
 	}
 

--- a/test/input/equil/config-with-drt-areaStrategy.xml
+++ b/test/input/equil/config-with-drt-areaStrategy.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
 	<module name="controler" >
-		<param name="lastIteration" value="10" />
+		<param name="lastIteration" value="11" />
 		<param name="outputDirectory" value="test/output/org/matsim/run/RunOptDrtEquilScenarioTest/test/" />
 		<param name="runId" value="test" />
 		<param name="overwriteFiles" value="deleteDirectoryIfExists" />

--- a/test/input/equil/config-with-drt-fareStrategy.xml
+++ b/test/input/equil/config-with-drt-fareStrategy.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
 	<module name="controler" >
-		<param name="lastIteration" value="10" />
+		<param name="lastIteration" value="11" />
 		<param name="outputDirectory" value="test/output/org/matsim/run/RunOptDrtEquilScenarioTest/test/" />
 		<param name="runId" value="test" />
 		<param name="overwriteFiles" value="deleteDirectoryIfExists" />

--- a/test/input/equil/config-with-drt-fleetStrategy.xml
+++ b/test/input/equil/config-with-drt-fleetStrategy.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
 	<module name="controler" >
-		<param name="lastIteration" value="10" />
+		<param name="lastIteration" value="11" />
 		<param name="outputDirectory" value="test/output/org/matsim/run/RunOptDrtEquilScenarioTest/test/" />
 		<param name="runId" value="test" />
 		<param name="overwriteFiles" value="deleteDirectoryIfExists" />

--- a/test/input/equil/config-with-drt-fleetStrategyProportional.xml
+++ b/test/input/equil/config-with-drt-fleetStrategyProportional.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
 	<module name="controler" >
-		<param name="lastIteration" value="10" />
+		<param name="lastIteration" value="11" />
 		<param name="outputDirectory" value="test/output/org/matsim/run/RunOptDrtEquilScenarioTest/test/" />
 		<param name="runId" value="test" />
 		<param name="overwriteFiles" value="deleteDirectoryIfExists" />


### PR DESCRIPTION
- move updateFleet/fare ... to IterationStartsEvent -> solves #5 
- have a separate reset method to reset data containers after updateFleet/Fare etc. has run but before the iteration really starts and new data is to be collected 
- some untangling of interdependencies of writeInfo() on updateFleet/Fare/() because now they are run in the opposite order
- on the long run at least for the Fleet strategies it would be much nicer to have something like: at each IterationEndsEvent calculate all statistics, decide upon fleet/fare/etc. modification, print that out as info (even if not implemented later), at the following IterationStartsEvent check that updateInterval condition then take planned modifications and implement them
- all tests run through but they seem very incomplete, many strategies are never tested, so no guarantee everything works as before